### PR TITLE
Core - Refactor and update SubscriptionService to follow same pattern as the others

### DIFF
--- a/src/main/java/no/ntnu/okse/core/event/PublisherChangeEvent.java
+++ b/src/main/java/no/ntnu/okse/core/event/PublisherChangeEvent.java
@@ -34,7 +34,8 @@ import no.ntnu.okse.core.subscription.Publisher;
 public class PublisherChangeEvent extends Event {
 
     public enum Type {
-        REGISTER
+        REGISTER,
+        UNREGISTER
     }
 
     Type type;

--- a/src/main/java/no/ntnu/okse/core/subscription/SubscriptionService.java
+++ b/src/main/java/no/ntnu/okse/core/subscription/SubscriptionService.java
@@ -128,45 +128,219 @@ public class SubscriptionService extends AbstractCoreService {
         }
     }
 
+    /* ------------------------------------------------------------------------------------------ */
+
+    /* Begin Service-Local methods */
+
+    /**
+     * This helper method injects a task into the task queue and handles interrupt exceptions
+     * @param task The SubscriptionTask to be executed
+     */
+    private void insertTask(SubscriptionTask task) {
+        try {
+            // Inject the task into the task queue
+            this.queue.put(task);
+        } catch (InterruptedException e) {
+            log.error("Interrupted while injecting task into queue");
+        }
+    }
+
+    /**
+     * Service-local private method to add a Subscriber to the list of subscribers
+     * @param s : A Subscriber instance with the proper fields set
+     */
+    private void addSubscriberLocal(Subscriber s) {
+        if (!_subscribers.contains(s)) {
+            // Add the subscriber
+            _subscribers.add(s);
+            log.info("Added new subscriber: " + s);
+            // Fire the subscribe event
+            fireSubcriptionChangeEvent(s, SubscriptionChangeEvent.Type.SUBSCRIBE);
+        } else {
+            log.warn("Attempt to add a subscriber that already exists!");
+        }
+    }
+
+    /**
+     * Service-local private method to remove a subscriber from the list of subscribers
+     * @param s : A Subscriber instance that exists in the subscribers set
+     */
+    private void removeSubscriberLocal(Subscriber s) {
+        if (_subscribers.contains(s)) {
+            // Remove the subscriber
+            _subscribers.remove(s);
+            log.info("Removed subscriber: " + s);
+            // Fire the unsubscribe event
+            fireSubcriptionChangeEvent(s, SubscriptionChangeEvent.Type.UNSUBSCRIBE);
+        } else {
+            log.warn("Attempt to remove a subscriber that did not exist!");
+        }
+    }
+
+    /**
+     * Service-local private method to renew the subscription for a particular subscriber
+     * @param s : The subscriber that is to be changed
+     * @param timeout : The new timeout time represented as seconds since unix epoch
+     */
+    private void renewSubscriberLocal(Subscriber s, long timeout) {
+        if (_subscribers.contains(s)) {
+            // Update the timeout field
+            s.setTimeout(timeout);
+            log.info("Renewed subscriber: " + s);
+            // Fire the renew event
+            fireSubcriptionChangeEvent(s, SubscriptionChangeEvent.Type.RENEW);
+        } else {
+            log.warn("Attempt to modify a subscriber that does not exist in the service!");
+        }
+    }
+
+    /**
+     * Service-local private method to pause the subscription for a particular subscriber
+     * @param s : The subscriber that is to be paused
+     */
+    private void pauseSubscriberLocal(Subscriber s) {
+        if (_subscribers.contains(s)) {
+            // Set the Paused attribute to true
+            s.setAttribute("paused", "true");
+            log.info("Paused subscriber: " + s);
+            // Fire the pause event
+            fireSubcriptionChangeEvent(s, SubscriptionChangeEvent.Type.PAUSE);
+        } else {
+            log.warn("Attempt to modify a subscriber that does not exist in the service!");
+        }
+    }
+
+    /**
+     * Service-local private method to register a publisher to the publisher set
+     * @param p : The publisher object that is to be registered
+     */
+    private void addPublisherLocal(Publisher p) {
+        if (!_publishers.contains(p)) {
+            // Add the publisher
+            _publishers.add(p);
+            log.info("Added publisher: " + p);
+            // Fire the register event
+            firePublisherChangeEvent(p, PublisherChangeEvent.Type.REGISTER);
+        } else {
+            log.warn("Attempt to add a publisher that already exists!");
+        }
+    }
+
+    /**
+     * Service-local private method to unregister a publisher from the publisher set
+     * @param p : A publisher object that exists in the publishers set
+     */
+    private void removePublisherLocal(Publisher p) {
+        if (_publishers.contains(p)) {
+            // Remove the publisher
+            _publishers.remove(p);
+            log.info("Removed publisher: " + p);
+            // Fire the remove event
+            firePublisherChangeEvent(p, PublisherChangeEvent.Type.UNREGISTER);
+        }
+    }
+    /* End Service-Local methods */
+
+    /* ------------------------------------------------------------------------------------------ */
+
     /* Begin subscriber public API */
-    public synchronized void addSubscriber(Subscriber s) {
-        _subscribers.add(s);
-        log.info("Added new subscriber: " + s);
-        fireSubcriptionChangeEvent(s, SubscriptionChangeEvent.Type.SUBSCRIBE);
+
+    /**
+     * Public method to add a Subscriber
+     * @param s The subscriber to be added
+     */
+    public void addSubscriber(Subscriber s) {
+        if (!_subscribers.contains(s)) {
+            // Create the job
+            Runnable job = () -> addSubscriberLocal(s);
+            // Initialize the SubscriptionTask wrapper
+            SubscriptionTask task = new SubscriptionTask(SubscriptionTask.Type.NEW_SUBSCRIBER, job);
+            // Inject the task
+            insertTask(task);
+        } else {
+            log.warn("Attempt to add a subscriber that already exists!");
+        }
     }
 
-    public synchronized void removeSubscriber(Subscriber s) {
-        _subscribers.remove(s);
-        log.info("Removed subscriber: " + s);
-        fireSubcriptionChangeEvent(s, SubscriptionChangeEvent.Type.UNSUBSCRIBE);
+    /**
+     * Public method to remove a Subscriber
+     * @param s A subscriber that exists in the subscribers set
+     */
+    public void removeSubscriber(Subscriber s) {
+        if (_subscribers.contains(s)) {
+            // Create the job
+            Runnable job = () -> removeSubscriberLocal(s);
+            // Initialize the SubscriptionTask wrapper
+            SubscriptionTask task = new SubscriptionTask(SubscriptionTask.Type.DELETE_SUBSCRIBER, job);
+            // Inject the task
+            insertTask(task);
+        } else {
+            log.warn("Attempt to remove a subscriber that did not exist!");
+        }
     }
 
-    public synchronized void pauseSubscriber(Subscriber s) {
-        s.setAttribute("paused", "true");
-        log.info("Subscriber paused: " + s);
-        fireSubcriptionChangeEvent(s, SubscriptionChangeEvent.Type.PAUSE);
+    /**
+     * Public method to renew a subscription
+     * @param s The subscriber object that is to be renewed
+     * @param timeout The new timeout of the subscription represented as seconds since unix epoch
+     */
+    public void renewSubscriber(Subscriber s, Long timeout) {
+        if (!_subscribers.contains(s)) {
+            // Create the job
+            Runnable job = () -> renewSubscriberLocal(s, timeout);
+            // Initialize the SubscriptionTask wrapper
+            SubscriptionTask task = new SubscriptionTask(SubscriptionTask.Type.UPDATE_SUBSCRIBER, job);
+            // Inject the task
+            insertTask(task);
+        } else {
+            log.warn("Attempt to modify a subscriber that did not exist in the service!");
+        }
     }
 
-    public synchronized void renewSubscriber(Subscriber s, Long timeout) {
-        s.setTimeout(timeout);
-        log.info("Subscriber renewed: " + s);
-        fireSubcriptionChangeEvent(s, SubscriptionChangeEvent.Type.RENEW);
+    /**
+     * Public method to pause a subscroption
+     * @param s The subciber object that is to be paused
+     */
+    public void pauseSubscriber(Subscriber s) {
+        if (_subscribers.contains(s)) {
+            // Create the job
+            Runnable job = () -> pauseSubscriberLocal(s);
+            // Initialize the SubscriptionTask wrapper
+            SubscriptionTask task = new SubscriptionTask(SubscriptionTask.Type.UPDATE_SUBSCRIBER, job);
+            // Inject the task
+            insertTask(task);
+        } else {
+            log.warn("Attempt to modify a subscriber that did not exist in the service!");
+        }
     }
     /* End subscriber public API */
 
+    /* ------------------------------------------------------------------------------------------ */
+
     /* Begin publisher public API */
+
+    /**
+     * Public method to register a publisher
+     * @param p The publisher object that is to be registered
+     */
     public synchronized void addPublisher(Publisher p) {
         _publishers.add(p);
         log.info("Publisher registered: " + p);
         firePublisherChangeEvent(p, PublisherChangeEvent.Type.REGISTER);
     }
 
+    /**
+     * Public method to unregister a publisher
+     * @param p A publisher object that exists in the publishers set
+     */
     public synchronized void removePublisher(Publisher p) {
         _publishers.remove(p);
         log.info("Publisher removed: " + p);
         firePublisherChangeEvent(p, PublisherChangeEvent.Type.REGISTER);
     }
     /* End publisher public API */
+
+    /* ------------------------------------------------------------------------------------------ */
 
     /**
      * Attempt to locate a subscriber by remote address, port and topic object.
@@ -185,6 +359,10 @@ public class SubscriptionService extends AbstractCoreService {
         }
         return null;
     }
+
+    /* ------------------------------------------------------------------------------------------ */
+
+    /* Begin listener support */
 
     /**
      * SubscriptionChange event listener support
@@ -237,4 +415,6 @@ public class SubscriptionService extends AbstractCoreService {
         PublisherChangeEvent rce = new PublisherChangeEvent(type, reg);
         _registrationListeners.stream().forEach(l -> l.publisherChanged(rce));
     }
+
+    /* End listener support */
 }


### PR DESCRIPTION
This separates public API and private service-local injector methods, driven by the task queue. This removes the need to synchronize the publicly exposed methods, as they are all executed from the queue in the SubscriptionService thread.