### PR TITLE
Core - Add dynamic bootup listener support registration across all core services

### DIFF
--- a/src/main/java/no/ntnu/okse/core/AbstractCoreService.java
+++ b/src/main/java/no/ntnu/okse/core/AbstractCoreService.java
@@ -57,6 +57,13 @@ public abstract class AbstractCoreService {
     public abstract void boot();
 
     /**
+     * This method must contain the operations needed for the subclass to register itself as a listener
+     * to the different objects it wants to listen to. This method will be called after all Core Services have
+     * been booted.
+     */
+    public abstract void registerListenerSupport();
+
+    /**
      * Main run method that will be called when the subclass' serverThread is started
      */
     public abstract void run();

--- a/src/main/java/no/ntnu/okse/core/CoreService.java
+++ b/src/main/java/no/ntnu/okse/core/CoreService.java
@@ -124,20 +124,14 @@ public class CoreService extends AbstractCoreService {
         this.bootCoreServices();
         log.info("Completed booting CoreServices");
 
-        // Call the registerListenerSupport() method on all registered Core Services
-        log.info("Setting up listener support for registered core services");
-        this.registerListenerSupportForAllCoreServices();
-        log.info("Completed setting up listener support for registered core services");
-
-
         // Call the boot() method on all registered ProtocolServers
         this.bootProtocolServers();
         log.info("Completed booting ProtocolServers");
 
-        // Register listenersupport for self to other objects now that the boot sequences have completed
-        log.info("Registering self as listener to other entities");
-        this.registerListenerSupport();
-        log.info("Completed self-registration of listener support");
+        // Call the registerListenerSupport() method on all registered Core , including self
+        log.info("Setting up listener support for all core services");
+        this.registerListenerSupportForAllCoreServices();
+        log.info("Completed setting up listener support for all core services");
 
         // Initiate main run loop, which awaits Events to be committed to the eventQueue
         while (_running) {
@@ -348,6 +342,10 @@ public class CoreService extends AbstractCoreService {
      * Private helper method that sets up listener support for all registered core services
      */
     private void registerListenerSupportForAllCoreServices() {
+        // Register listener registration on self
+        this.registerListenerSupport();
+        // Register listener support on other registered core services
         services.forEach(s -> s.registerListenerSupport());
+
     }
 }

--- a/src/main/java/no/ntnu/okse/core/CoreService.java
+++ b/src/main/java/no/ntnu/okse/core/CoreService.java
@@ -101,6 +101,17 @@ public class CoreService extends AbstractCoreService {
     }
 
     /**
+     * This method can contain registration calls to objects that CoreService should listen to.
+     * Please note that in order for the CoreService itself to listen to other registered core services
+     * this method must be called AFTER the bootAllCoreServices() method has completed in the boot() sequence of
+     * this class
+     */
+    @Override
+    public void registerListenerSupport() {
+        // Add listener registration here
+    }
+
+    /**
      * Starts the main loop of the CoreService thread.
      */
     @Override
@@ -113,9 +124,20 @@ public class CoreService extends AbstractCoreService {
         this.bootCoreServices();
         log.info("Completed booting CoreServices");
 
+        // Call the registerListenerSupport() method on all registered Core Services
+        log.info("Setting up listener support for registered core services");
+        this.registerListenerSupportForAllCoreServices();
+        log.info("Completed setting up listener support for registered core services");
+
+
         // Call the boot() method on all registered ProtocolServers
         this.bootProtocolServers();
         log.info("Completed booting ProtocolServers");
+
+        // Register listenersupport for self to other objects now that the boot sequences have completed
+        log.info("Registering self as listener to other entities");
+        this.registerListenerSupport();
+        log.info("Completed self-registration of listener support");
 
         // Initiate main run loop, which awaits Events to be committed to the eventQueue
         while (_running) {
@@ -319,5 +341,13 @@ public class CoreService extends AbstractCoreService {
      */
     private void bootProtocolServers() {
         protocolServers.forEach(ps -> ps.boot());
+    }
+
+
+    /**
+     * Private helper method that sets up listener support for all registered core services
+     */
+    private void registerListenerSupportForAllCoreServices() {
+        services.forEach(s -> s.registerListenerSupport());
     }
 }

--- a/src/main/java/no/ntnu/okse/core/messaging/Message.java
+++ b/src/main/java/no/ntnu/okse/core/messaging/Message.java
@@ -32,6 +32,7 @@ import org.springframework.security.crypto.codec.Hex;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.LocalDateTime;
+import java.util.HashMap;
 
 /**
  * Created by Aleksander Skraastad (myth) on 4/17/15.
@@ -47,6 +48,7 @@ public class Message {
     private final String message;
     private final String messageID;
     private static Logger log;
+    private HashMap<String, String> attributes;
 
     // Mutable fields
     private LocalDateTime processed;
@@ -61,6 +63,7 @@ public class Message {
         this.message = message;
         this.systemMessage = false;
         this.messageID = generateMessageID();
+        this.attributes = new HashMap<>();
     }
 
     /**
@@ -148,6 +151,26 @@ public class Message {
     public LocalDateTime setProcessed() {
         if (!isProcessed()) this.processed = LocalDateTime.now();
         return this.processed;
+    }
+
+    /**
+     * Set an attribute on this Message object
+     * @param key They key of the attribute
+     * @param value The value of the attribute
+     */
+    public void setAttribute(String key, String value) {
+        if (attributes.containsKey(key)) attributes.replace(key, value);
+        else attributes.put(key, value);
+    }
+
+    /**
+     * Retrieve an attribute from this message object
+     * @param key The key to fetch the value of
+     * @return The value if the attribute exists, null otherwise
+     */
+    public String getAttribute(String key) {
+        if (attributes.containsKey(key)) return attributes.get(key);
+        return null;
     }
 
     /**

--- a/src/main/java/no/ntnu/okse/core/messaging/MessageService.java
+++ b/src/main/java/no/ntnu/okse/core/messaging/MessageService.java
@@ -94,6 +94,16 @@ public class MessageService extends AbstractCoreService {
     }
 
     /**
+     * This method must contain the operations needed for the subclass to register itself as a listener
+     * to the different objects it wants to listen to. This method will be called after all Core Services have
+     * been booted.
+     */
+    @Override
+    public void registerListenerSupport() {
+        // TODO: Register self as listener to stuff
+    }
+
+    /**
      * This method should be called from within the run-scope of the serverThread thread instance
      */
     public void run() {

--- a/src/main/java/no/ntnu/okse/core/messaging/MessageService.java
+++ b/src/main/java/no/ntnu/okse/core/messaging/MessageService.java
@@ -33,6 +33,7 @@ import org.apache.log4j.Logger;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.concurrent.LinkedBlockingQueue;
 
@@ -47,6 +48,7 @@ public class MessageService extends AbstractCoreService {
     private static MessageService _singleton;
     private static Thread _serviceThread;
     private LinkedBlockingQueue<Message> queue;
+    private HashMap<String, Message> latestMessages;
 
     /**
      * Private Constructor that recieves invocation from getInstance, enabling the singleton pattern for this class
@@ -62,6 +64,7 @@ public class MessageService extends AbstractCoreService {
     protected void init() {
         log.info("Initializing MessageService...");
         queue = new LinkedBlockingQueue<>();
+        latestMessages = new HashMap<>();
         _invoked = true;
     }
 
@@ -133,7 +136,12 @@ public class MessageService extends AbstractCoreService {
                     // Tell the ExecutorService to execute the following job
                     CoreService.getInstance().execute(() -> {
                         // Fetch all registered protocol servers, and call the sendMessage() method on them
-                        CoreService.getInstance().getAllProtocolServers().forEach(p -> p.sendMessage(m));
+                        CoreService.getInstance().getAllProtocolServers().forEach(p -> {
+                            // Add message to latestMessages cache
+                            latestMessages.put(m.getTopic().getFullTopicString(), m);
+                            // Fire the sendMessage on all servers
+                            p.sendMessage(m);
+                        });
                         // Set the message as processed, and store the completion time
                         LocalDateTime completedAt = m.setProcessed();
                         log.info("Message successfully distributed: " + m + " (" + completedAt + ")");
@@ -147,6 +155,17 @@ public class MessageService extends AbstractCoreService {
         } else {
             log.error("Run method called before invocation of the MessageService getInstance method");
         }
+    }
+
+    /**
+     * Retrieves the latest message sent on a specific topic
+     * @param topic The topic to retrieve the latest message for
+     * @return The message object for the specified topic, null if there has not been any messages yet
+     */
+    public Message getLatestMessage(String topic) {
+        if (latestMessages.containsKey(topic)) return latestMessages.get(topic);
+
+        return null;
     }
 
     /**

--- a/src/main/java/no/ntnu/okse/core/messaging/MessageService.java
+++ b/src/main/java/no/ntnu/okse/core/messaging/MessageService.java
@@ -187,6 +187,18 @@ public class MessageService extends AbstractCoreService {
         }
     }
 
+    /**
+     * Adds a Message object into the message queue for distribution
+     * @param m The message object to be distributed
+     */
+    public void distributeMessage(Message m) {
+        try {
+            this.queue.put(m);
+        } catch (InterruptedException e) {
+            log.error("Interrupted while trying to inject message into queue");
+        }
+    }
+
     /* ----------------------------------------------------------------------------------------------- */
 
     /* Private helper methods */

--- a/src/main/java/no/ntnu/okse/core/subscription/Publisher.java
+++ b/src/main/java/no/ntnu/okse/core/subscription/Publisher.java
@@ -25,7 +25,6 @@
 package no.ntnu.okse.core.subscription;
 
 import no.ntnu.okse.Application;
-import no.ntnu.okse.core.event.SystemEvent;
 
 import java.util.HashMap;
 
@@ -73,6 +72,14 @@ public class Publisher {
      */
     public String getHost() {
         return host;
+    }
+
+    /**
+     * Retrieves the raw topic string this publisher has registered to
+     * @return The raw topic string this publisher is registered to
+     */
+    public String getTopic() {
+        return this.topic;
     }
 
     /**
@@ -152,6 +159,10 @@ public class Publisher {
         return false;
     }
 
+    /**
+     * Fetches a concatenation of host and port as a string
+     * @return The host and port of the subscriber as a string
+     */
     public String getHostAndPort() {
         return host + ":" + port;
     }

--- a/src/main/java/no/ntnu/okse/core/subscription/Publisher.java
+++ b/src/main/java/no/ntnu/okse/core/subscription/Publisher.java
@@ -152,6 +152,10 @@ public class Publisher {
         return false;
     }
 
+    public String getHostAndPort() {
+        return host + ":" + port;
+    }
+
     @Override
     public String toString() {
         return "Publisher [" + originProtocol + "] " + host + ":" + port + " on topic: " + topic;

--- a/src/main/java/no/ntnu/okse/core/subscription/Publisher.java
+++ b/src/main/java/no/ntnu/okse/core/subscription/Publisher.java
@@ -154,7 +154,7 @@ public class Publisher {
 
     @Override
     public String toString() {
-        return "[" + originProtocol + "] " + host + ":" + port + " on topic: " + topic;
+        return "Publisher [" + originProtocol + "] " + host + ":" + port + " on topic: " + topic;
     }
 
 }

--- a/src/main/java/no/ntnu/okse/core/subscription/Subscriber.java
+++ b/src/main/java/no/ntnu/okse/core/subscription/Subscriber.java
@@ -165,6 +165,6 @@ public class Subscriber {
      */
     @Override
     public String toString() {
-        return "[" + originProtocol + "] " + host + ":" + port + " on topic: " + topic;
+        return "Subscriber [" + originProtocol + "] " + host + ":" + port + " on topic: " + topic;
     }
 }

--- a/src/main/java/no/ntnu/okse/core/subscription/SubscriptionService.java
+++ b/src/main/java/no/ntnu/okse/core/subscription/SubscriptionService.java
@@ -420,9 +420,9 @@ public class SubscriptionService extends AbstractCoreService implements TopicCha
      * @param topic A raw topic string of the topic to select subscribers from
      * @return A HashSet of Subscriber objects that have subscribed to the specified topic
      */
-    public HashSet<Subscriber> getAllPublishersForTopic(String topic) {
+    public HashSet<Publisher> getAllPublishersForTopic(String topic) {
         // Initialize a collector
-        HashSet<Subscriber> results = new HashSet<>();
+        HashSet<Publisher> results = new HashSet<>();
 
         // TODO: Will this trigger concurrent modification exception if new subs are added during iteration?
 

--- a/src/main/java/no/ntnu/okse/core/subscription/SubscriptionService.java
+++ b/src/main/java/no/ntnu/okse/core/subscription/SubscriptionService.java
@@ -31,6 +31,7 @@ import no.ntnu.okse.core.event.listeners.PublisherChangeListener;
 import no.ntnu.okse.core.event.listeners.SubscriptionChangeListener;
 import no.ntnu.okse.core.topic.Topic;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.concurrent.LinkedBlockingQueue;
 
@@ -406,6 +407,10 @@ public class SubscriptionService extends AbstractCoreService {
      */
     public HashSet<Subscriber> getAllSubscribers() {
         return (HashSet<Subscriber>) _subscribers.clone();
+    }
+
+    public HashSet<Publisher> getAllPublishers() {
+        return (HashSet<Publisher>) _publishers.clone();
     }
 
     /* ------------------------------------------------------------------------------------------ */

--- a/src/main/java/no/ntnu/okse/core/subscription/SubscriptionService.java
+++ b/src/main/java/no/ntnu/okse/core/subscription/SubscriptionService.java
@@ -437,13 +437,21 @@ public class SubscriptionService extends AbstractCoreService implements TopicCha
     }
 
     /**
-     * Retrive a HashSet of all subscribers on the broker
+     * Retrive a HashSet of all subscribers on the broker. This HashSet is a shallow clone of the internal
+     * data structure, preventing unintended modification.
+     * 
      * @return A HashSet of Subscriber objects that have subscribed on the broker
      */
     public HashSet<Subscriber> getAllSubscribers() {
         return (HashSet<Subscriber>) _subscribers.clone();
     }
 
+    /**
+     * Retrieve a HashSet of all publishers on the broker. This HashSet is a shallow clone of the internal
+     * data structure, preventing unintended modification.
+     *
+     * @return A HashSet of Publisher objects that have registered on the broker
+     */
     public HashSet<Publisher> getAllPublishers() {
         return (HashSet<Publisher>) _publishers.clone();
     }

--- a/src/main/java/no/ntnu/okse/core/subscription/SubscriptionService.java
+++ b/src/main/java/no/ntnu/okse/core/subscription/SubscriptionService.java
@@ -27,9 +27,12 @@ package no.ntnu.okse.core.subscription;
 import no.ntnu.okse.core.AbstractCoreService;
 import no.ntnu.okse.core.event.PublisherChangeEvent;
 import no.ntnu.okse.core.event.SubscriptionChangeEvent;
+import no.ntnu.okse.core.event.TopicChangeEvent;
 import no.ntnu.okse.core.event.listeners.PublisherChangeListener;
 import no.ntnu.okse.core.event.listeners.SubscriptionChangeListener;
+import no.ntnu.okse.core.event.listeners.TopicChangeListener;
 import no.ntnu.okse.core.topic.Topic;
+import no.ntnu.okse.core.topic.TopicService;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -40,7 +43,7 @@ import java.util.concurrent.LinkedBlockingQueue;
  * <p>
  * okse is licenced under the MIT licence.
  */
-public class SubscriptionService extends AbstractCoreService {
+public class SubscriptionService extends AbstractCoreService implements TopicChangeListener {
 
     private static SubscriptionService _singleton;
     private static Thread _serviceThread;
@@ -97,6 +100,17 @@ public class SubscriptionService extends AbstractCoreService {
             _serviceThread.setName("SubscriptionService");
             _serviceThread.start();
         }
+    }
+
+    /**
+     * This method must contain the operations needed for this class to register itself as a listener
+     * to the different instances it wants to listen to. This method will be called after all Core Services have
+     * been booted.
+     */
+    @Override
+    public void registerListenerSupport() {
+        // Register self as listener to TopicService events
+        TopicService.getInstance().addTopicChangeListener(this);
     }
 
     /**
@@ -402,6 +416,27 @@ public class SubscriptionService extends AbstractCoreService {
     }
 
     /**
+     * Retrieve a HashSet of all subscribers that have subscribed to a specific topic
+     * @param topic A raw topic string of the topic to select subscribers from
+     * @return A HashSet of Subscriber objects that have subscribed to the specified topic
+     */
+    public HashSet<Subscriber> getAllPublishersForTopic(String topic) {
+        // Initialize a collector
+        HashSet<Subscriber> results = new HashSet<>();
+
+        // TODO: Will this trigger concurrent modification exception if new subs are added during iteration?
+
+        // Iterate over all subscribers
+        getAllPublishers().stream()
+                // Only pass on those who match topic argument
+                .filter(p -> p.getTopic().equals(topic))
+                        // Collect in the results set
+                .forEach(p -> results.add(p));
+
+        return results;
+    }
+
+    /**
      * Retrive a HashSet of all subscribers on the broker
      * @return A HashSet of Subscriber objects that have subscribed on the broker
      */
@@ -470,4 +505,22 @@ public class SubscriptionService extends AbstractCoreService {
     }
 
     /* End listener support */
+
+    /* Start observation methods */
+
+    @Override
+    public void topicChanged(TopicChangeEvent event) {
+        if (event.getType().equals(TopicChangeEvent.Type.DELETE)) {
+
+            // Fetch the raw topic string from the event Topic object
+            String fullRawTopicString = event.getData().getFullTopicString();
+
+            // Remove all the subscribers for the topic that was deleted
+            getAllSubscribersForTopic(fullRawTopicString).forEach(s -> removeSubscriber(s));
+            // Remove all the publishers for the topic that was deleted
+            getAllPublishersForTopic(fullRawTopicString).forEach(p -> removePublisher(p));
+        }
+    }
+
+    /* End observation methods */
 }

--- a/src/main/java/no/ntnu/okse/core/topic/TopicService.java
+++ b/src/main/java/no/ntnu/okse/core/topic/TopicService.java
@@ -95,6 +95,16 @@ public class TopicService extends AbstractCoreService {
     }
 
     /**
+     * This method must contain the operations needed for the subclass to register itself as a listener
+     * to the different objects it wants to listen to. This method will be called after all Core Services have
+     * been booted.
+     */
+    @Override
+    public void registerListenerSupport() {
+        // TODO: Register self as listener to stuff
+    }
+
+    /**
      * This method Stops the TopicService
      * @throws InterruptedException An exception that might occur if thread is interrupted while waiting for put
      * command thread lock to open up.

--- a/src/main/java/no/ntnu/okse/protocol/wsn/WSNCommandProxy.java
+++ b/src/main/java/no/ntnu/okse/protocol/wsn/WSNCommandProxy.java
@@ -635,7 +635,7 @@ public class WSNCommandProxy extends AbstractNotificationBroker {
             }
 
             NotificationMessageHolderType holderType = WSNTools.generateNotificationMessageHolderType(
-                    currentMessage, currentMessage.getTopic().getFullTopicString(), pubRef
+                currentMessage, currentMessage.getTopic().getFullTopicString(), subRef, pubRef, askedFor.getDialect()
             );
 
             response.getAny().add(holderType.getMessage());

--- a/src/main/java/no/ntnu/okse/protocol/wsn/WSNCommandProxy.java
+++ b/src/main/java/no/ntnu/okse/protocol/wsn/WSNCommandProxy.java
@@ -477,7 +477,7 @@ public class WSNCommandProxy extends AbstractNotificationBroker {
 
         // Extract the publisher endpoint
         W3CEndpointReference publisherEndpoint = registerPublisherRequest.getPublisherReference();
-        log.debug("Publisher endpint is: " + publisherEndpoint);
+        log.debug("Publisher endpoint is: " + publisherEndpoint);
 
         // If we do not have an endpoint, produce a soapfault
         if (publisherEndpoint == null) {

--- a/src/main/java/no/ntnu/okse/protocol/wsn/WSNCommandProxy.java
+++ b/src/main/java/no/ntnu/okse/protocol/wsn/WSNCommandProxy.java
@@ -627,11 +627,16 @@ public class WSNCommandProxy extends AbstractNotificationBroker {
         } else {
             GetCurrentMessageResponse response = new GetCurrentMessageResponse();
 
-            if (!(currentMessage.getPublisher() == null)) {
+            String pubRef = null;
+            String subRef = null;
 
+            if (!(currentMessage.getPublisher() == null)) {
+                pubRef = currentMessage.getPublisher().getAttribute(WSNSubscriptionManager.WSN_ENDPOINT_TOKEN);
             }
 
-            NotificationMessageHolderType holderType = WSNTools.generateNotificationMessageHolderType(currentMessage());
+            NotificationMessageHolderType holderType = WSNTools.generateNotificationMessageHolderType(
+                    currentMessage, currentMessage.getTopic().getFullTopicString(), pubRef
+            );
 
             response.getAny().add(holderType.getMessage());
 

--- a/src/main/java/no/ntnu/okse/protocol/wsn/WSNCommandProxy.java
+++ b/src/main/java/no/ntnu/okse/protocol/wsn/WSNCommandProxy.java
@@ -607,13 +607,16 @@ public class WSNCommandProxy extends AbstractNotificationBroker {
         // Find out which topic there was asked for (Exceptions automatically thrown)
         TopicExpressionType askedFor = getCurrentMessageRequest.getTopic();
 
+        // Check if there was a specified topic element
         if (askedFor == null) {
             log.warn("Topic missing from getCurrentMessage request");
             ExceptionUtilities.throwInvalidTopicExpressionFault("en", "Topic missing from request.");
         }
 
+        // Fetch the topic QNames
         List<QName> topicQNames = TopicValidator.evaluateTopicExpressionToQName(askedFor, connection.getRequestInformation().getNamespaceContext(askedFor));
 
+        // Fetch the topic as a String
         String topicName = TopicUtils.topicToString(topicQNames);
 
         // Fetch the latest message from the MessageService
@@ -625,17 +628,17 @@ public class WSNCommandProxy extends AbstractNotificationBroker {
 
             return null;
         } else {
+            // Initialize the response object
             GetCurrentMessageResponse response = new GetCurrentMessageResponse();
 
+            // Initialize our subscriptionReference and publisherReference
             String pubRef = null;
             String subRef = null;
 
-            if (!(currentMessage.getPublisher() == null)) {
-                pubRef = currentMessage.getPublisher().getAttribute(WSNSubscriptionManager.WSN_ENDPOINT_TOKEN);
-            }
+
 
             NotificationMessageHolderType holderType = WSNTools.generateNotificationMessageHolderType(
-                currentMessage, currentMessage.getTopic().getFullTopicString(), subRef, pubRef, askedFor.getDialect()
+                currentMessage, subRef, pubRef, askedFor.getDialect()
             );
 
             response.getAny().add(holderType.getMessage());

--- a/src/main/java/no/ntnu/okse/protocol/wsn/WSNCommandProxy.java
+++ b/src/main/java/no/ntnu/okse/protocol/wsn/WSNCommandProxy.java
@@ -627,16 +627,11 @@ public class WSNCommandProxy extends AbstractNotificationBroker {
         } else {
             GetCurrentMessageResponse response = new GetCurrentMessageResponse();
 
-            // Create the needed WS-Nu wrappers needed for the response
-            NotificationMessageHolderType holderType = new NotificationMessageHolderType();
-            NotificationMessageHolderType.Message wsnMessage = new NotificationMessageHolderType.Message();
-            wsnMessage.setAny(currentMessage.getMessage());
-            holderType.setMessage(wsnMessage);
-            W3CEndpointReferenceBuilder builder = new W3CEndpointReferenceBuilder();
-            builder.address(currentMessage.getPublisher().getHostAndPort());
+            if (!(currentMessage.getPublisher() == null)) {
 
-            if (currentMessage.getPublisher().getAttribute())
+            }
 
+            NotificationMessageHolderType holderType = WSNTools.generateNotificationMessageHolderType(currentMessage());
 
             response.getAny().add(holderType.getMessage());
 

--- a/src/main/java/no/ntnu/okse/protocol/wsn/WSNSubscriptionManager.java
+++ b/src/main/java/no/ntnu/okse/protocol/wsn/WSNSubscriptionManager.java
@@ -31,6 +31,7 @@ public class WSNSubscriptionManager extends AbstractSubscriptionManager implemen
 
     public static final String WSN_SUBSCRIBER_TOKEN = "wsn-subscriberkey";
     public static final String WSN_DIALECT_TOKEN = "wsn-dialect";
+    public static final String WSN_ENDPOINT_TOKEN = "wsn-endpoint";
 
     private static Logger log;
     private SubscriptionService _subscriptionService = null;

--- a/src/main/java/no/ntnu/okse/protocol/wsn/WSNTools.java
+++ b/src/main/java/no/ntnu/okse/protocol/wsn/WSNTools.java
@@ -37,7 +37,7 @@ import javax.xml.ws.wsaddressing.W3CEndpointReferenceBuilder;
  */
 public class WSNTools {
     public static NotificationMessageHolderType generateNotificationMessageHolderType(
-        Message message, String topic, String publisherReference, String subscriptionReference
+        Message message, String topic, String publisherReference
     ) {
         NotificationMessageHolderType holderType = new NotificationMessageHolderType();
         NotificationMessageHolderType.Message innerMessage = new NotificationMessageHolderType.Message();
@@ -51,8 +51,6 @@ public class WSNTools {
         } else {
             endRefBuilder.address(message.getPublisher().getHostAndPort());
         }
-
-        QName
 
         holderType.setProducerReference(endRefBuilder.build());
 

--- a/src/main/java/no/ntnu/okse/protocol/wsn/WSNTools.java
+++ b/src/main/java/no/ntnu/okse/protocol/wsn/WSNTools.java
@@ -1,0 +1,41 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2015 Norwegian Defence Research Establishment / NTNU
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package no.ntnu.okse.protocol.wsn;
+
+import org.oasis_open.docs.wsn.b_2.NotificationMessageHolderType;
+
+/**
+ * Created by Aleksander Skraastad (myth) on 4/21/15.
+ * <p>
+ * okse is licenced under the MIT licence.
+ */
+public class WSNTools {
+    public static NotificationMessageHolderType generateNotificationMessageHolderType(
+        Object message, String topic, String publisherReference, String subscriptionReference
+    ) {
+        NotificationMessageHolderType holderType = new NotificationMessageHolderType();
+        return null;
+    }
+}

--- a/src/main/java/no/ntnu/okse/protocol/wsn/WSNTools.java
+++ b/src/main/java/no/ntnu/okse/protocol/wsn/WSNTools.java
@@ -25,9 +25,9 @@
 package no.ntnu.okse.protocol.wsn;
 
 import no.ntnu.okse.core.messaging.Message;
-import org.oasis_open.docs.wsn.b_2.NotificationMessageHolderType;
+import org.oasis_open.docs.wsn.b_2.*;
+import org.oasis_open.docs.wsn.t_1.*;
 
-import javax.xml.namespace.QName;
 import javax.xml.ws.wsaddressing.W3CEndpointReferenceBuilder;
 
 /**
@@ -36,14 +36,47 @@ import javax.xml.ws.wsaddressing.W3CEndpointReferenceBuilder;
  * okse is licenced under the MIT licence.
  */
 public class WSNTools {
-    public static NotificationMessageHolderType generateNotificationMessageHolderType(
-        Message message, String topic, String publisherReference
-    ) {
-        NotificationMessageHolderType holderType = new NotificationMessageHolderType();
-        NotificationMessageHolderType.Message innerMessage = new NotificationMessageHolderType.Message();
 
-        innerMessage.setAny(message.getMessage());
-        holderType.setMessage(innerMessage);
+    // Initialize the WSN XML Object factories
+    public static org.oasis_open.docs.wsn.b_2.ObjectFactory b2_factory = new org.oasis_open.docs.wsn.b_2.ObjectFactory();
+    public static org.oasis_open.docs.wsn.t_1.ObjectFactory t1_factory = new org.oasis_open.docs.wsn.t_1.ObjectFactory();
+
+    // Namespace references
+    public static final String _ConcreteTopicExpression = "http://docs.oasis-open.org/wsn/t-1/TopicExpression/Concrete";
+    public static final String _SimpleTopicExpression = "http://docs.oasis-open.org/wsn/t-1/TopicExpression/Simple";
+
+    /**
+     * Generates a WS-Notification Notification Message from the provided arguments
+     *
+     * @param message An OKSE message object containing all the required fields
+     * @param topic The raw topic string this message is destined for
+     * @param subscriptionReference The subscription reference endpoint
+     * @param publisherReference The publisher reference endpoint
+     * @param dialect The dialect used for this message
+     * @return A completely built NotificationMessageHolderType used in WS-Nu for storing notifications
+     */
+    public static NotificationMessageHolderType generateNotificationMessageHolderType(
+        Message message,
+        String topic,
+        String subscriptionReference,
+        String publisherReference,
+        String dialect
+    ) {
+        // Create the HolderType
+        NotificationMessageHolderType holderType = b2_factory.createNotificationMessageHolderType();
+        // Create the Message object
+        NotificationMessageHolderType.Message innerMessage = b2_factory.createNotificationMessageHolderTypeMessage();
+        // Create the TopicExpressionType
+        TopicExpressionType topicType = b2_factory.createTopicExpressionType();
+        // Set the Dialect on the TopicExpressionType
+        topicType.setDialect(dialect);
+        // Add the actual topic to the TopicExpressionType
+        topicType.getContent().add(topic);
+        // Set the Topic on the HolderType
+        holderType.setTopic(topicType);
+
+        // Set the actual contents of the message to the Message element
+        innerMessage.setAny("Test");
 
         W3CEndpointReferenceBuilder endRefBuilder = new W3CEndpointReferenceBuilder();
         if (!message.getPublisher().getAttribute("wsn-endpoint").equals(null)) {

--- a/src/main/java/no/ntnu/okse/protocol/wsn/WSNTools.java
+++ b/src/main/java/no/ntnu/okse/protocol/wsn/WSNTools.java
@@ -24,7 +24,11 @@
 
 package no.ntnu.okse.protocol.wsn;
 
+import no.ntnu.okse.core.messaging.Message;
 import org.oasis_open.docs.wsn.b_2.NotificationMessageHolderType;
+
+import javax.xml.namespace.QName;
+import javax.xml.ws.wsaddressing.W3CEndpointReferenceBuilder;
 
 /**
  * Created by Aleksander Skraastad (myth) on 4/21/15.
@@ -33,9 +37,25 @@ import org.oasis_open.docs.wsn.b_2.NotificationMessageHolderType;
  */
 public class WSNTools {
     public static NotificationMessageHolderType generateNotificationMessageHolderType(
-        Object message, String topic, String publisherReference, String subscriptionReference
+        Message message, String topic, String publisherReference, String subscriptionReference
     ) {
         NotificationMessageHolderType holderType = new NotificationMessageHolderType();
-        return null;
+        NotificationMessageHolderType.Message innerMessage = new NotificationMessageHolderType.Message();
+
+        innerMessage.setAny(message.getMessage());
+        holderType.setMessage(innerMessage);
+
+        W3CEndpointReferenceBuilder endRefBuilder = new W3CEndpointReferenceBuilder();
+        if (!message.getPublisher().getAttribute("wsn-endpoint").equals(null)) {
+            endRefBuilder.address(message.getPublisher().getHostAndPort() + message.getPublisher().getAttribute(WSNSubscriptionManager.WSN_ENDPOINT_TOKEN));
+        } else {
+            endRefBuilder.address(message.getPublisher().getHostAndPort());
+        }
+
+        QName
+
+        holderType.setProducerReference(endRefBuilder.build());
+
+        return holderType;
     }
 }


### PR DESCRIPTION
This PR also adds listening support from the subscription service to the topic service, that ultimately allows for removal of subscribers and publishers that are registered on a topic when a topic has been deleted.